### PR TITLE
Refactor： should keep `event` originated from pg_replication untouched

### DIFF
--- a/lib/postgrex_wal/message.ex
+++ b/lib/postgrex_wal/message.ex
@@ -59,10 +59,10 @@ defmodule PostgrexWal.Message do
     ?c => StreamCommit
   }
 
-  @spec decode(key :: integer, event :: {:in_transaction, binary()} | binary()) :: struct()
-  def decode(key, {:in_transaction, <<transaction_id::32, payload::binary>>}) do
+  @spec decode(event :: {:in_transaction, binary()} | binary()) :: struct()
+  def decode({:in_transaction, <<key::8, transaction_id::32, payload::binary>>}) do
     @modules[key].decode(payload) |> struct(transaction_id: transaction_id)
   end
 
-  def decode(key, event), do: @modules[key].decode(event)
+  def decode(<<key::8, payload::binary>>), do: @modules[key].decode(payload)
 end

--- a/lib/postgrex_wal/message.ex
+++ b/lib/postgrex_wal/message.ex
@@ -61,8 +61,10 @@ defmodule PostgrexWal.Message do
 
   @spec decode(event :: {:in_transaction, binary()} | binary()) :: struct()
   def decode({:in_transaction, <<key::8, transaction_id::32, payload::binary>>}) do
-    @modules[key].decode(payload) |> struct(transaction_id: transaction_id)
+    decode(<<key::8>> <> payload) |> struct(transaction_id: transaction_id)
   end
 
-  def decode(<<key::8, payload::binary>>), do: @modules[key].decode(payload)
+  for {key, module} <- @modules do
+    def decode(<<unquote(key)::8, payload::binary>>), do: unquote(module).decode(payload)
+  end
 end

--- a/lib/postgrex_wal/messages/message.ex
+++ b/lib/postgrex_wal/messages/message.ex
@@ -23,8 +23,8 @@ defmodule PostgrexWal.Messages.Message do
   """
   use PostgrexWal.Message
 
-  typedstruct do
-    field :transaction_id, integer()
+  typedstruct enforce: true do
+    field :transaction_id, integer(), enforce: false
     field :flags, [{:transactional, boolean()}]
     field :lsn, String.t()
     field :prefix, String.t()

--- a/lib/postgrex_wal/messages/relation.ex
+++ b/lib/postgrex_wal/messages/relation.ex
@@ -41,8 +41,8 @@ defmodule PostgrexWal.Messages.Relation do
   use PostgrexWal.Message
   alias PostgrexWal.Messages.Relation.Column
 
-  typedstruct do
-    field :transaction_id, integer()
+  typedstruct enforce: true do
+    field :transaction_id, integer(), enforce: false
     field :relation_oid, integer()
     field :namespace, String.t()
     field :relation_name, String.t()

--- a/lib/postgrex_wal/messages/truncate.ex
+++ b/lib/postgrex_wal/messages/truncate.ex
@@ -19,8 +19,8 @@ defmodule PostgrexWal.Messages.Truncate do
   """
   use PostgrexWal.Message
 
-  typedstruct do
-    field :transaction_id, integer()
+  typedstruct enforce: true do
+    field :transaction_id, integer(), enforce: false
     field :number_of_relations, integer()
     field :options, [{:truncate, :cascade | :restart_identity}]
     field :relation_oids, list(integer)

--- a/lib/postgrex_wal/messages/type.ex
+++ b/lib/postgrex_wal/messages/type.ex
@@ -19,8 +19,8 @@ defmodule PostgrexWal.Messages.Type do
   """
   use PostgrexWal.Message
 
-  typedstruct do
-    field :transaction_id, integer()
+  typedstruct enforce: true do
+    field :transaction_id, integer(), enforce: false
     field :type_oid, integer()
     field :namespace, String.t()
     field :type_name, String.t()

--- a/test/postgrex_wal/messages/delete_test.exs
+++ b/test/postgrex_wal/messages/delete_test.exs
@@ -64,7 +64,7 @@ defmodule PostgrexWal.Messages.DeleteTest do
                relation_oid: 22_887,
                transaction_id: 123
              },
-             PostgrexWal.Message.decode(?D, {:in_transaction, <<123::32, @event>>})
+             PostgrexWal.Message.decode({:in_transaction, <<?D, 123::32, @event>>})
            )
   end
 end

--- a/test/postgrex_wal/messages/message_test.exs
+++ b/test/postgrex_wal/messages/message_test.exs
@@ -27,7 +27,7 @@ defmodule PostgrexWal.Messages.MessageTest do
                prefix: "my_test",
                transaction_id: 123
              },
-             PostgrexWal.Message.decode(?M, {:in_transaction, <<123::32, @event>>})
+             PostgrexWal.Message.decode({:in_transaction, <<?M, 123::32, @event>>})
            )
   end
 end

--- a/test/postgrex_wal/messages/type_test.exs
+++ b/test/postgrex_wal/messages/type_test.exs
@@ -23,7 +23,7 @@ defmodule PostgrexWal.Messages.TypeTest do
                type_name: "my_type",
                type_oid: 31_204
              },
-             PostgrexWal.Message.decode(?Y, {:in_transaction, <<123::32, @event>>})
+             PostgrexWal.Message.decode({:in_transaction, <<?Y, 123::32, @event>>})
            )
   end
 end


### PR DESCRIPTION
1.  从源头的 `pg_replication_connection` 拿到 `event` 消息。
2. 根据 `protocol 2` 区分出是否处于 `transaction` 中。若是，则对消息打上标记，以标识处于 `transcation`中。
3. 但，对原始的 `event` 消息本身，应该保持不变（不插入，也不拆分）。附带上标识，原汁原味的向后传，或是，调`decoder` 去解码处理。
4. 原有的消息为：`event`，若在 `transaction` 中，则变为：`{:in_transaction, event}`。否则，保持不变，仍为：`event`。


#### 从语义上对：`PostgrexWal.Message.decode/1` 的修改。

```elixir
  @spec decode(event :: {:in_transaction, binary()} | binary()) :: struct()
  def decode({:in_transaction, <<key::8, transaction_id::32, payload::binary>>}) do
    @modules[key].decode(payload) |> struct(transaction_id: transaction_id)
  end

  def decode(<<key::8, payload::binary>>), do: @modules[key].decode(payload)
```