### PR TITLE
feat: produce overflow control

### DIFF
--- a/lib/postgrex_wal/pg_producer.ex
+++ b/lib/postgrex_wal/pg_producer.ex
@@ -50,6 +50,11 @@ defmodule PostgrexWal.PgProducer do
 
   typedstruct do
     field :pg_source, pid(), default: nil
+    field :queue, :queue.queue(), default: :queue.new()
+    field :pending_demand, non_neg_integer(), default: 0
+    field :max_size, non_neg_integer(), default: 10
+    field :current_size, non_neg_integer(), default: 0
+    field :over_flowed?, boolean(), default: false
   end
 
   @impl true
@@ -58,11 +63,6 @@ defmodule PostgrexWal.PgProducer do
     Logger.info("pg_producer init...")
     send(self(), {:start_pg_source, opts})
     {:producer, %__MODULE__{}}
-  end
-
-  @impl true
-  def handle_demand(_demand, state) do
-    {:noreply, [], state}
   end
 
   @impl true
@@ -75,22 +75,35 @@ defmodule PostgrexWal.PgProducer do
   Broadway.NoopAcknowledger.init() produce: {Broadway.NoopAcknowledger, nil, nil}
   Broadway.CallerAcknowledger.init({pid, ref}, term) produce: {Broadway.CallerAcknowledger, {#PID<0.275.0>, ref}, term}
   """
-  def handle_info({:message, %Commit{} = message}, state) do
-    event = %Broadway.Message{
-      data: message,
-      acknowledger: {__MODULE__, state.pg_source, :ack_data}
-    }
 
-    {:noreply, [event], state}
+  def handle_info({:message, _}, %{over_flowed?: true} = state) do
+    {:noreply, [], state}
   end
 
-  def handle_info({:message, message}, state) do
+  def handle_info({:message, message}, %{current_size: s, max_size: max} = state)
+      when s + 1 < max do
+    acker =
+      if is_struct(message, Commit),
+        do: {__MODULE__, state.pg_source, :ack_data},
+        else: Broadway.NoopAcknowledger.init()
+
     event = %Broadway.Message{
       data: message,
-      acknowledger: Broadway.NoopAcknowledger.init()
+      acknowledger: acker
     }
 
-    {:noreply, [event], state}
+    state = %{state | queue: :queue.in(event, state.queue), current_size: s + 1}
+    dispatch_events([], state)
+  end
+
+  def handle_info({:message, _}, state) do
+    {:noreply, [], %{state | over_flowed?: true}}
+  end
+
+  @impl true
+  def handle_demand(incoming_demand, state) do
+    state = %{state | pending_demand: state.pending_demand + incoming_demand}
+    dispatch_events([], state)
   end
 
   @doc """
@@ -110,5 +123,28 @@ defmodule PostgrexWal.PgProducer do
       end)
 
     lsn && PostgrexWal.PgSource.ack(pg_source, lsn)
+  end
+
+  defp dispatch_events(events, %{pending_demand: 0} = state) do
+    {:noreply, Enum.reverse(events), state}
+  end
+
+  defp dispatch_events(events, state) do
+    case :queue.out(state.queue) do
+      {{:value, event}, queue} ->
+        state = %{
+          state
+          | pending_demand: state.pending_demand - 1,
+            queue: queue,
+            current_size: state.current_size - 1
+        }
+
+        dispatch_events([event | events], state)
+
+      {:empty, _queue} ->
+        if state.over_flowed?,
+          do: {:stop, :over_flowed, state},
+          else: {:noreply, Enum.reverse(events), state}
+    end
   end
 end

--- a/lib/postgrex_wal/pg_producer.ex
+++ b/lib/postgrex_wal/pg_producer.ex
@@ -61,8 +61,9 @@ defmodule PostgrexWal.PgProducer do
   # opts has been injected with {broadway: Keyword.t()} by Broadway behaviour.
   def init(opts) do
     Logger.info("pg_producer init...")
+    {init_opts, opts} = Keyword.split(opts, [:max_size])
     send(self(), {:start_pg_source, opts})
-    {:producer, %__MODULE__{}}
+    {:producer, struct!(__MODULE__, init_opts)}
   end
 
   @impl true
@@ -105,7 +106,7 @@ defmodule PostgrexWal.PgProducer do
 
   @impl true
   def handle_demand(incoming_demand, %{pending_demand: p} = state) do
-    state = %{state | pending_demand: p + incoming_demand}
+    state = %{state | pending_demand: incoming_demand + p}
     dispatch_events([], state)
   end
 

--- a/lib/postgrex_wal/pg_producer.ex
+++ b/lib/postgrex_wal/pg_producer.ex
@@ -88,7 +88,7 @@ defmodule PostgrexWal.PgProducer do
       when s + 1 < max do
     acker =
       if is_struct(message, Commit),
-        do: {__MODULE__, state.pg_source, :ack_data},
+        do: {__MODULE__, {:pg_source, state.pg_source}, :ack_data},
         else: Broadway.NoopAcknowledger.init()
 
     event = %Broadway.Message{
@@ -118,7 +118,7 @@ defmodule PostgrexWal.PgProducer do
   """
   @behaviour Broadway.Acknowledger
   @impl true
-  def ack(pg_source, successful_messages, _failed_messages) do
+  def ack({:pg_source, pg_source}, successful_messages, _failed_messages) do
     lsn =
       successful_messages
       |> Enum.reverse()

--- a/lib/postgrex_wal/pg_source_util.ex
+++ b/lib/postgrex_wal/pg_source_util.ex
@@ -4,6 +4,14 @@ defmodule PostgrexWal.PgSourceUtil do
   """
 
   require Logger
+  alias PostgrexWal.PgSource
+
+  @doc """
+  The logical replication protocol sends individual transactions one by one.
+  This means that all messages between a pair of Begin and Commit messages belong to the same transaction.
+  It also sends changes of large in-progress transactions between a pair of Stream Start and Stream Stop messages.
+  The last stream of such a transaction contains Stream Commit or Stream Abort message.
+  """
 
   @modules %{
     Begin => ?B,
@@ -21,52 +29,34 @@ defmodule PostgrexWal.PgSourceUtil do
     Type => ?Y,
     Update => ?U
   }
-
-  @doc """
-  The logical replication protocol sends individual transactions one by one.
-  This means that all messages between a pair of Begin and Commit messages belong to the same transaction.
-  It also sends changes of large in-progress transactions between a pair of Stream Start and Stream Stop messages.
-  The last stream of such a transaction contains Stream Commit or Stream Abort message.
-  """
-
   @stream_start @modules[StreamStart]
   @stream_stop @modules[StreamStop]
-  @spec decode_wal(binary(), PostgrexWal.PgSource.t()) :: {struct(), PostgrexWal.PgSource.t()}
-  def decode_wal(<<key::8, rest::binary>> = event, state) do
-    in_stream? =
-      case key do
-        @stream_start ->
-          state.in_stream? && Logger.error("stream flag consecutively true")
-          true
 
-        @stream_stop ->
-          state.in_stream? || Logger.error("stream flag consecutively false")
-          false
+  @spec decode_wal(binary(), PgSource.t()) :: {struct(), PgSource.t()}
+  def decode_wal(<<@stream_start::8, _rest::binary>> = event, state) do
+    if state.in_stream?, do: Logger.error("stream flag consecutively true")
+    {decode(event), %{state | in_stream?: true}}
+  end
 
-        _ ->
-          state.in_stream?
-      end
+  def decode_wal(<<@stream_stop::8, _rest::binary>> = event, state) do
+    unless state.in_stream?, do: Logger.error("stream flag consecutively false")
+    {decode(event), %{state | in_stream?: false}}
+  end
 
-    message =
-      if in_stream? and streamable?(key) do
-        <<transaction_id::32, rest::binary>> = rest
-        decode(<<key::8>> <> rest) |> struct(transaction_id: transaction_id)
-      else
-        decode(event)
-      end
+  @streamable_modules [Delete, Insert, Message, Relation, Truncate, Type, Update]
+  @streamable_keys @modules |> Map.take(@streamable_modules) |> Map.values()
+  def decode_wal(<<key::8, transaction_id::32, rest::binary>>, %{in_stream?: true} = state)
+      when key in @streamable_keys do
+    message = decode(<<key::8>> <> rest) |> struct!(transaction_id: transaction_id)
+    {message, state}
+  end
 
-    {message, %{state | in_stream?: in_stream?}}
+  def decode_wal(event, state) do
+    {decode(event), state}
   end
 
   for {module, key} <- @modules do
     m = Module.concat(PostgrexWal.Messages, module)
     defp decode(<<unquote(key)::8, payload::binary>>), do: unquote(m).decode(payload)
   end
-
-  @streamable_modules [Delete, Insert, Message, Relation, Truncate, Type, Update]
-  for {_module, key} <- Map.take(@modules, @streamable_modules) do
-    defp streamable?(unquote(key)), do: true
-  end
-
-  defp streamable?(_key), do: false
 end

--- a/test/postgrex_wal/pg_producer_test.exs
+++ b/test/postgrex_wal/pg_producer_test.exs
@@ -105,6 +105,6 @@ defmodule PostgrexWal.PgProducerTest do
   defp source_id(context), do: :"source-#{context.module}-#{context.test}"
 
   defp case_identity(context) do
-    "#{context.module |> Module.split() |> Enum.map_join(&Macro.underscore/1)}_#{context.line}"
+    "#{context.module |> Module.split() |> Enum.map_join("__", &Macro.underscore/1)}_#{context.line}"
   end
 end


### PR DESCRIPTION
The mismatch between the rates of production and consumption leads to various problems. 
 
Possible solutions needed: 
1. Cache data in some way. But there are various thresholds. 
2. Handling of exceeding the highest threshold 
3. Processing below the minimum threshold.

Currently
- [x] Use explicit queue to buffer events.
- [x] Use state field to buffer demand.
- [x] Exceeding the `max_size` will result in a restart.

Original Issue #22 