### PR TITLE
refactor: update CI env

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres_test
+          POSTGRES_DB: postgres
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+env:
+  ELIXIR_VERSION: 1.14.3
+  OTP_VERSION: 25.2.2
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -43,11 +47,11 @@ jobs:
     needs: mix
     services:
       pg:
-        image: postgres
+        image: postgres:15.2-bullseye
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
+          POSTGRES_DB: postgres_test
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/prepare-ci/action.yml
+++ b/.github/workflows/prepare-ci/action.yml
@@ -11,8 +11,8 @@ runs:
   steps:
     - uses: erlef/setup-beam@v1
       with:
-        otp-version: 25.0
-        elixir-version: 1.14.0-otp-25
+        otp-version: ${{ env.OTP_VERSION }}
+        elixir-version: ${{ env.ELIXIR_VERSION }}
 
     - id: cache
       uses: actions/cache@v3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.14.0-otp-25
-erlang 25.0
+elixir 1.14.3-otp-25
+erlang 25.2.2

--- a/lib/postgrex_wal/message.ex
+++ b/lib/postgrex_wal/message.ex
@@ -39,14 +39,10 @@ defmodule PostgrexWal.Message do
   @streamable_keys @modules |> Map.take(@streamable_modules) |> Map.values()
 
   expr =
-    @modules
-    |> Enum.map(fn {module, _key} ->
-      m = Module.concat(@module_prefix, module)
-      quote do: unquote(m).t()
-    end)
-    |> Enum.reduce(fn type, acc ->
-      quote do: unquote(type) | unquote(acc)
-    end)
+    for {m, _} <- @modules, module = Module.concat(@module_prefix, m), reduce: nil do
+      nil -> quote do: unquote(module).t()
+      acc -> quote do: unquote(module).t() | unquote(acc)
+    end
 
   @type t() :: unquote(expr)
   @type tuple_data() :: nil | :unchanged_toast | {:text, binary()} | {:binary, bitstring()}

--- a/test/postgrex_wal/pg_producer_test.exs
+++ b/test/postgrex_wal/pg_producer_test.exs
@@ -91,8 +91,7 @@ defmodule PostgrexWal.PgProducerTest do
     start_my_broadway(context)
     insert_huge_quantity_users(context.table_name)
 
-    for i <- 1..@user_count do
-      uid = "#{i}"
+    for i <- 1..@user_count, uid = "#{i}" do
       assert_receive(%Message{data: %Insert{tuple_data: [text: ^uid]}})
     end
   end

--- a/test/support/postgrex_wal/psql.ex
+++ b/test/support/postgrex_wal/psql.ex
@@ -30,7 +30,7 @@ defmodule PostgrexWal.PSQL do
     [
       hostname: System.get_env("PG_HOST", "localhost"),
       port: System.get_env("PG_PORT", "5432"),
-      database: System.get_env("PG_DATABASE", "postgres"),
+      database: System.get_env("PG_DATABASE", "postgres_test"),
       username: System.get_env("PG_USERNAME", "postgres"),
       password: System.get_env("PG_PASSWORD", "postgres")
     ]

--- a/test/support/postgrex_wal/psql.ex
+++ b/test/support/postgrex_wal/psql.ex
@@ -30,7 +30,7 @@ defmodule PostgrexWal.PSQL do
     [
       hostname: System.get_env("PG_HOST", "localhost"),
       port: System.get_env("PG_PORT", "5432"),
-      database: System.get_env("PG_DATABASE", "postgres_test"),
+      database: System.get_env("PG_DATABASE", "postgres"),
       username: System.get_env("PG_USERNAME", "postgres"),
       password: System.get_env("PG_PASSWORD", "postgres")
     ]

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
 ExUnit.start(
-  assert_receive_timeout: 15_000,
-  refute_receive_timeout: 5_000
+  assert_receive_timeout: 60_000,
+  refute_receive_timeout: 1_000
 )

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,4 @@
 ExUnit.start(
-  assert_receive_timeout: 60_000,
+  assert_receive_timeout: 30_000,
   refute_receive_timeout: 1_000
 )


### PR DESCRIPTION
Updated the Ci related configuration to use explicit configuration values to make the test environment more explicit.
- [x] use docker image: `postgres:15.2-bullseye`
- [x] use `postgres_test` as test db.
- [x] elixir-1.14.3
- [x] erlang-25.2.2

Again: Optimized snippets in `message.ex` to be more concise.